### PR TITLE
Support stacktraces for Cloud prod logger.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -66,9 +66,12 @@ func NewLoggerConfigForGCP() zap.Config {
 			EncodeDuration: zapcore.SecondsDurationEncoder,
 			EncodeCaller:   zapcore.ShortCallerEncoder,
 		},
-		DisableStacktrace: true,
-		OutputPaths:       []string{"stderr"},
-		ErrorOutputPaths:  []string{"stderr"},
+		Sampling: &zap.SamplingConfig{
+			Initial:    100,
+			Thereafter: 100,
+		},
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
 	}
 }
 


### PR DESCRIPTION
If stacktraces for errors are sent GCP Monitoring will automatically start categorizing errors in the Error Reporting system making it easy to detect trends over time.

See: https://cloud.google.com/error-reporting/docs/setup/cloud-run