### PR TITLE
Support GCP Error Reporting

### DIFF
--- a/gcpcore/core.go
+++ b/gcpcore/core.go
@@ -1,0 +1,126 @@
+// Package gcpcore is a custom zap.Core that formats Error logs for GCP Error Reporting
+package gcpcore
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Based on https://github.com/blendle/zapdriver
+
+type errorReportingCore struct {
+	base           zapcore.Core
+	extra          []zapcore.Field
+	serviceContext serviceContext
+}
+
+// WrapCore returns a zap.Option that wraps the current core with the error
+// reporting core. Any ErrorLogs will now be reported in a format that can ingest
+// into GCP Error Reporting.
+//
+// Example:
+// 	core := zap.Must(golog.NewLoggerConfigForGCP().Build(
+//			gcpcore.WrapCore(gcpcore.CloudRunServiceAndVersion()),
+//		))
+//	logger := core.Sugar().Named("web_server")
+//
+func WrapCore(name, version string) zap.Option {
+	return zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+		return &errorReportingCore{
+			base:           c,
+			serviceContext: *newServiceContext(name, version),
+		}
+	})
+}
+
+// CloudRunServiceAndVersion returns a service name and version based on the predefined
+// env vars K_SERVICE & K_REVISION. Also works for GCP App Engine.
+// See: https://cloud.google.com/run/docs/container-contract
+func CloudRunServiceAndVersion() (string, string) {
+	return os.Getenv("K_SERVICE"), os.Getenv("K_REVISION")
+}
+
+// Enabled tests if the Core is enabled for the level.
+func (c *errorReportingCore) Enabled(level zapcore.Level) bool {
+	return c.base.Enabled(level)
+}
+
+// With returns a new core with the given fields.
+func (c *errorReportingCore) With(f []zapcore.Field) zapcore.Core {
+	return &errorReportingCore{c, f, c.serviceContext}
+}
+
+// Check adds the core logger to the entry if enabled.
+func (c *errorReportingCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(e.Level) {
+		return ce.AddCore(e, c)
+	}
+
+	return ce
+}
+
+// Write writes the entry to the underlying core. If an Error level entry is written
+// the core will add the fields needed for GCP Error Reporting then write to the
+// underlying core.
+func (c *errorReportingCore) Write(e zapcore.Entry, f []zapcore.Field) error {
+	fields := []zapcore.Field{}
+	fields = append(fields, c.extra...)
+	fields = append(fields, f...)
+
+	// Only run on Error logs
+	if zapcore.ErrorLevel.Enabled(e.Level) {
+		fields = c.withSourceLocation(e, fields)
+		fields = c.withServiceContext(fields)
+		fields = c.withErrorReport(e, fields)
+	}
+
+	return c.base.Write(e, fields)
+}
+
+// Sync calls the underly cores Sync.
+func (c *errorReportingCore) Sync() error {
+	return c.base.Sync()
+}
+
+func (c *errorReportingCore) withSourceLocation(ent zapcore.Entry, fields []zapcore.Field) []zapcore.Field {
+	// If the source location was manually set, don't overwrite it
+	for i := range fields {
+		if fields[i].Key == sourceKey {
+			return fields
+		}
+	}
+
+	if !ent.Caller.Defined {
+		return fields
+	}
+
+	return append(fields, SourceLocation(ent.Caller.PC, ent.Caller.File, ent.Caller.Line, true))
+}
+
+func (c *errorReportingCore) withServiceContext(fields []zapcore.Field) []zapcore.Field {
+	// If the service context was manually set, don't overwrite it
+	for i := range fields {
+		if fields[i].Key == serviceContextKey {
+			return fields
+		}
+	}
+
+	return append(fields, zapServiceContext(c.serviceContext))
+}
+
+func (c *errorReportingCore) withErrorReport(ent zapcore.Entry, fields []zapcore.Field) []zapcore.Field {
+	// If the error report was manually set, don't overwrite it
+	for i := range fields {
+		if fields[i].Key == contextKey {
+			return fields
+		}
+	}
+
+	if !ent.Caller.Defined {
+		return fields
+	}
+
+	return append(fields, zapErrorReport(ent.Caller.PC, ent.Caller.File, ent.Caller.Line, true))
+}

--- a/gcpcore/error_report.go
+++ b/gcpcore/error_report.go
@@ -1,0 +1,70 @@
+package gcpcore
+
+import (
+	"runtime"
+	"strconv"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Based on https://github.com/blendle/zapdriver
+
+const contextKey = "context"
+
+// errorReport adds the correct Stackdriver "context" field for getting the log line
+// reported as error.
+//
+// see: https://cloud.google.com/error-reporting/docs/formatting-error-messages
+func zapErrorReport(pc uintptr, file string, line int, ok bool) zap.Field {
+	return zap.Object(contextKey, newReportContext(pc, file, line, ok))
+}
+
+// reportLocation is the source code location information associated with the log entry
+// for the purpose of reporting an error,
+// if any.
+type reportLocation struct {
+	File     string `json:"filePath"`
+	Line     string `json:"lineNumber"`
+	Function string `json:"functionName"`
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaller interface.
+func (location reportLocation) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("filePath", location.File)
+	enc.AddString("lineNumber", location.Line)
+	enc.AddString("functionName", location.Function)
+
+	return nil
+}
+
+// reportContext is the context information attached to a log for reporting errors.
+type reportContext struct {
+	ReportLocation reportLocation `json:"reportLocation"`
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaller interface.
+func (context reportContext) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return enc.AddObject("reportLocation", context.ReportLocation)
+}
+
+func newReportContext(pc uintptr, file string, line int, ok bool) *reportContext {
+	if !ok {
+		return nil
+	}
+
+	var function string
+	if fn := runtime.FuncForPC(pc); fn != nil {
+		function = fn.Name()
+	}
+
+	context := &reportContext{
+		ReportLocation: reportLocation{
+			File:     file,
+			Line:     strconv.Itoa(line),
+			Function: function,
+		},
+	}
+
+	return context
+}

--- a/gcpcore/service_context.go
+++ b/gcpcore/service_context.go
@@ -1,0 +1,40 @@
+package gcpcore
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Based on https://github.com/blendle/zapdriver
+
+const serviceContextKey = "serviceContext"
+
+// zapServiceContext adds the correct service information adding the log line
+// It is a required field if an error needs to be reported.
+//
+// see: https://cloud.google.com/error-reporting/reference/rest/v1beta1/zapServiceContext
+// see: https://cloud.google.com/error-reporting/docs/formatting-error-messages
+func zapServiceContext(sc serviceContext) zap.Field {
+	return zap.Object(serviceContextKey, sc)
+}
+
+type serviceContext struct {
+	Name    string `json:"service"`
+	Version string `json:"version"`
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaller interface.
+func (sc serviceContext) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("service", sc.Name)
+	enc.AddString("version", sc.Version)
+
+	return nil
+}
+
+// newServiceContext returns a new service context with name and version.
+func newServiceContext(name, version string) *serviceContext {
+	return &serviceContext{
+		Name:    name,
+		Version: version,
+	}
+}

--- a/gcpcore/source.go
+++ b/gcpcore/source.go
@@ -1,0 +1,68 @@
+package gcpcore
+
+import (
+	"runtime"
+	"strconv"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Based on https://github.com/blendle/zapdriver
+
+const sourceKey = "logging.googleapis.com/sourceLocation"
+
+// SourceLocation adds the correct Stackdriver "SourceLocation" field.
+//
+// see: https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation
+func SourceLocation(pc uintptr, file string, line int, ok bool) zap.Field {
+	return zap.Object(sourceKey, newSource(pc, file, line, ok))
+}
+
+// source is the source code location information associated with the log entry,
+// if any.
+type source struct {
+	// Optional. Source file name. Depending on the runtime environment, this
+	// might be a simple name or a fully-qualified name.
+	File string `json:"file"`
+
+	// Optional. Line within the source file. 1-based; 0 indicates no line number
+	// available.
+	Line string `json:"line"`
+
+	// Optional. Human-readable name of the function or method being invoked, with
+	// optional context such as the class or package name. This information may be
+	// used in contexts such as the logs viewer, where a file and line number are
+	// less meaningful.
+	//
+	// The format should be dir/package.func.
+	Function string `json:"function"`
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaller interface.
+func (source source) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("file", source.File)
+	enc.AddString("line", source.Line)
+	enc.AddString("function", source.Function)
+
+	return nil
+}
+
+func newSource(pc uintptr, file string, line int, ok bool) *source {
+	if !ok {
+		return nil
+	}
+
+	var function string
+	if fn := runtime.FuncForPC(pc); fn != nil {
+		function = fn.Name()
+	}
+
+	source := &source{
+		File:     file,
+		Line:     strconv.Itoa(line),
+		Function: function,
+	}
+
+	return source
+}


### PR DESCRIPTION
This optionally enables GCP Error Reporting from Cloud Run by properly formatting any error log messages. Error Reporting is extremly helpful when trying to understand failure rates overtime and alert on new types of errors after releases.