### PR TITLE
Update golangci-lint dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/edaniels/golinters v0.0.4
-	github.com/golangci/golangci-lint v1.38.0
+	github.com/golangci/golangci-lint v2.4.0
 	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.23.0
 	golang.org/x/tools v0.6.0 // indirect


### PR DESCRIPTION
golangci-lint pulls in github.com/golangci/asciicheck instead of github.com/tdakkota/asciicheck (which has been deleted)